### PR TITLE
Improve error messaging for git commands

### DIFF
--- a/pkg/in/command.go
+++ b/pkg/in/command.go
@@ -92,7 +92,10 @@ func (command *Command) Run(destination string, request Request) (Response, erro
 		}
 	}
 
-	os.Chdir(destination)
+	err = os.Chdir(destination)
+	if err != nil {
+		return Response{}, err
+	}
 
 	err = command.runner.Run("remote", "add", "source", source.String())
 	if err != nil {
@@ -116,7 +119,10 @@ func (command *Command) Run(destination string, request Request) (Response, erro
 		}
 	}
 
-	notes, _ := json.Marshal(mr)
+	notes, err := json.Marshal(mr)
+	if err != nil {
+		return Response{}, err
+	}
 	err = os.WriteFile(".git/merge-request.json", notes, 0644)
 	if err != nil {
 		return Response{}, err

--- a/pkg/in/git.go
+++ b/pkg/in/git.go
@@ -1,8 +1,10 @@
 package in
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type GitRunner interface {
@@ -23,7 +25,7 @@ func (r DefaultRunner) Run(args ...string) error {
 	command.Stderr = os.Stderr
 	err := command.Run()
 	if err != nil {
-		return err
+		return fmt.Errorf("'git %s': %s", strings.Join(args, " "), err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
Certain git commands can exit with unhelpful error messages like `exit code 1`. This helps by outputing the command that caused the error.